### PR TITLE
Fix Secp256k1 Base & Scalar Field Arithmetic

### DIFF
--- a/field/base_field.py
+++ b/field/base_field.py
@@ -70,8 +70,18 @@ class BaseField:
         c[6], carry = adc(self._limbs[6], rhs._limbs[6], carry)
         c[7], carry = adc(self._limbs[7], rhs._limbs[7], carry)
 
-        c[0] += carry * 977
-        c[1] += carry
+        one = [977, 1, 0, 0, 0, 0, 0, 0]
+        one = [i * carry for i in one]
+
+        carry = 0
+        c[0], carry = adc(c[0], one[0], carry)
+        c[1], carry = adc(c[1], one[1], carry)
+        c[2], carry = adc(c[2], one[2], carry)
+        c[3], carry = adc(c[3], one[3], carry)
+        c[4], carry = adc(c[4], one[4], carry)
+        c[5], carry = adc(c[5], one[5], carry)
+        c[6], carry = adc(c[6], one[6], carry)
+        c[7], _ = adc(c[7], one[7], carry)
 
         return BaseField(c)
 

--- a/field/base_field_utils.py
+++ b/field/base_field_utils.py
@@ -216,8 +216,18 @@ def montgomery_mul(a: List[int], b: List[int]) -> List[int]:
     c[14], carry = mac(c[14], q, prime[7], carry)
     c[15], pc = adc(c[15], pc, carry)
 
-    c[8] += pc * 977
-    c[9] += pc
+    one = [977, 1, 0, 0, 0, 0, 0, 0]
+    one = [i * pc for i in one]
+
+    carry = 0
+    c[8], carry = adc(c[8], one[0], carry)
+    c[9], carry = adc(c[9], one[1], carry)
+    c[10], carry = adc(c[10], one[2], carry)
+    c[11], carry = adc(c[11], one[3], carry)
+    c[12], carry = adc(c[12], one[4], carry)
+    c[13], carry = adc(c[13], one[5], carry)
+    c[14], carry = adc(c[14], one[6], carry)
+    c[15], _ = adc(c[15], one[7], carry)
 
     return c[8:16]
 

--- a/field/scalar_field.py
+++ b/field/scalar_field.py
@@ -74,11 +74,18 @@ class ScalarField:
         c[6], carry = adc(self._limbs[6], rhs._limbs[6], carry)
         c[7], carry = adc(self._limbs[7], rhs._limbs[7], carry)
 
-        c[0] += carry * 801750719
-        c[1] += carry * 1076732275
-        c[2] += carry * 1354194884
-        c[3] += carry * 1162945305
-        c[4] += carry
+        one = [801750719, 1076732275, 1354194884, 1162945305, 1, 0, 0, 0]
+        one = [i * carry for i in one]
+
+        carry = 0
+        c[0], carry = adc(c[0], one[0], carry)
+        c[1], carry = adc(c[1], one[1], carry)
+        c[2], carry = adc(c[2], one[2], carry)
+        c[3], carry = adc(c[3], one[3], carry)
+        c[4], carry = adc(c[4], one[4], carry)
+        c[5], carry = adc(c[5], one[5], carry)
+        c[6], carry = adc(c[6], one[6], carry)
+        c[7], _ = adc(c[7], one[7], carry)
 
         return ScalarField(c)
 

--- a/field/scalar_field_utils.py
+++ b/field/scalar_field_utils.py
@@ -216,11 +216,18 @@ def montgomery_mul(a: List[int], b: List[int]) -> List[int]:
     c[14], carry = mac(c[14], q, prime[7], carry)
     c[15], pc = adc(c[15], pc, carry)
 
-    c[8] += pc * 801750719
-    c[9] += pc * 1076732275
-    c[10] += pc * 1354194884
-    c[11] += pc * 1162945305
-    c[12] += pc
+    one = [801750719, 1076732275, 1354194884, 1162945305, 1, 0, 0, 0]
+    one = [i * pc for i in one]
+
+    carry = 0
+    c[8], carry = adc(c[8], one[0], carry)
+    c[9], carry = adc(c[9], one[1], carry)
+    c[10], carry = adc(c[10], one[2], carry)
+    c[11], carry = adc(c[11], one[3], carry)
+    c[12], carry = adc(c[12], one[4], carry)
+    c[13], carry = adc(c[13], one[5], carry)
+    c[14], carry = adc(c[14], one[6], carry)
+    c[15], _ = adc(c[15], one[7], carry)
 
     return c[8:16]
 


### PR DESCRIPTION
This PR makes necessary changes so that carry bit, obtained in the final step of addition/ multiplication over secp256k1 base/ scalar field, is not ignored. 